### PR TITLE
update rocoto to 1.3.7 (rocoto/1.3.7-fix module) on Gaea-c6 and Derecho

### DIFF
--- a/modulefiles/wflow_derecho.lua
+++ b/modulefiles/wflow_derecho.lua
@@ -5,8 +5,8 @@ on the CISL machine Derecho (Cray)
 
 whatis([===[Loads libraries for running the UFS SRW Workflow on Derecho ]===])
 
-append_path("MODULEPATH","/glade/work/epicufsrt/contrib/derecho/rocoto/modulefiles")
-load("rocoto")
+append_path("MODULEPATH","/glade/work/epicufsrt/contrib/derecho/modulefiles")
+load("rocoto/1.3.7-fix")
 
 unload("python")
 

--- a/modulefiles/wflow_gaeac6.lua
+++ b/modulefiles/wflow_gaeac6.lua
@@ -6,8 +6,8 @@ the NOAA RDHPC machine Gaea C6
 whatis([===[Loads libraries needed for running the UFS SRW App on gaea c6 ]===])
 
 unload("python")
-prepend_path("MODULEPATH","/ncrc/proj/epic/rocoto/modulefiles/")
-load("rocoto")
+prepend_path("MODULEPATH","/ncrc/proj/epic/c6/modulefiles/")
+load("rocoto/1.3.7-fix")
 load("conda")
 
 pushenv("MKLROOT", "/opt/intel/oneapi/mkl/2023.2.0/")


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 
Rocoto/1.3.7-fix version is installed on Derecho and Gaea-c6
It is not an out-of-the-box install, as it required additional installations and adaptations to build rocoto libraries.

Rocoto repository installed:
`https://github.com/christopherwharrop/rocoto.git 1.3.7-fix`
branch: ` feature/modernize-install`

As prerequisites to building the rocoto libraries, ruby-3.4.3 was installed on Gaea-c6, 
and  libxml2-v2.12.5 on Derecho, as well as additional code adaptation to use libxml2-v2.12.5 libraries.

Locations of modulefiles and rocoto install:
on `Derecho` 
```
/glade/work/epicufsrt/contrib/derecho/modulefiles/rocoto/1.3.7-fix.lua
/glade/work/epicufsrt/contrib/derecho/rocoto-1.3.7-fix/

```

on `Gaea-c6`:

```
/ncrc/proj/epic/c6/modulefiles/rocoto/1.3.7-fix.lua
/ncrc/proj/epic/c6/installs/rocoto/1.3.7-fix
```


## TESTS CONDUCTED: 
Tested functionality of the rocoto/1.3.7-fix module/installation on Derecho and Gaeac6

