### PR TITLE
Update rocoto installation locations on Derecho and Gaea-c6

### DIFF
--- a/modulefiles/wflow_derecho.lua
+++ b/modulefiles/wflow_derecho.lua
@@ -6,7 +6,7 @@ on the CISL machine Derecho (Cray)
 whatis([===[Loads libraries for running the UFS SRW Workflow on Derecho ]===])
 
 append_path("MODULEPATH","/glade/work/epicufsrt/contrib/derecho/modulefiles")
-load("rocoto/1.3.7-fix")
+load("rocoto/1.3.7")
 
 unload("python")
 

--- a/modulefiles/wflow_gaeac6.lua
+++ b/modulefiles/wflow_gaeac6.lua
@@ -7,7 +7,7 @@ whatis([===[Loads libraries needed for running the UFS SRW App on gaea c6 ]===])
 
 unload("python")
 prepend_path("MODULEPATH","/ncrc/proj/epic/c6/modulefiles/")
-load("rocoto/1.3.7-fix")
+load("rocoto/1.3.7")
 load("conda")
 
 pushenv("MKLROOT", "/opt/intel/oneapi/mkl/2023.2.0/")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Reinstalled rocoto package using an updated INSTALL script as in the following PR116: 
https://github.com/christopherwharrop/rocoto/pull/116

Loading rocoto module on Gaea:
```
module use /ncrc/proj/epic/c6/modulefiles
module load rocoto/1.3.7
```
Modulefile: /ncrc/proj/epic/c6/modulefiles/rocoto/1.3.7.lua
Install directory: /ncrc/proj/epic/c6/installs/rocoto/1.3.7

Loading rocoto module on Derecho:
```
module use /glade/work/epicufsrt/contrib/derecho/modulefiles
module load rocoto/1.3.7
```
Modulefile: /glade/work/epicufsrt/contrib/derecho/modulefiles/rocoto/1.3.7.lua
Install directory: /glade/work/epicufsrt/contrib/derecho/rocoto-1.3.7

### Type of change
<!-- Please delete options that are not relevant. Add an X to check off a box. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## TESTS CONDUCTED: 
<!-- Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required"). Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit! -->
<!-- Add an X to check off a box. -->

- [x] derecho.intel - fundamental tests
- [ ] gaea.intel
- [x] gaea-c6.intel -fundamental tests
- [ ] hera.gnu
- [ ] hera.intel
- [ ] hercules.intel
- [ ] jet.intel
- [ ] orion.intel
- [ ] wcoss2.intel
- [ ] NOAA Cloud (indicate which platform)
- [ ] Jenkins
- [ ] fundamental test suite
- [ ] comprehensive tests (specify *which* if a subset was used)



